### PR TITLE
fix a bug to allow saving init_net.pb

### DIFF
--- a/src/caffe2/binaries/mnist.cc
+++ b/src/caffe2/binaries/mnist.cc
@@ -309,8 +309,8 @@ void run() {
 
   // with open(os.path.join(root_folder, "deploy_net.pbtxt"), 'w') as fid:
   // fid.write(str(deploy_model.net.Proto()))
-  std::vector<string> external(initDeployModel.external_input().begin(),
-                               initDeployModel.external_input().end());
+  std::vector<string> external(predictDeployModel.external_input().begin(),
+                               predictDeployModel.external_input().end());
   for (auto &param : external) {
     auto tensor = GetTensor(*workspace.GetBlob(param));
     auto op = initDeployModel.add_op();


### PR DESCRIPTION
There is no external input for init model. All the external inputs are added to predict model. Therefore, in your example, saving init_net.pb will be a nearly empty file while it should contain all trained weight and bias info. 