### PR TITLE
To fix the compiling error of std c++11 and the change of Caffe2 shared library name.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@ if(CUDA_LIBRARIES)
   include_directories(${CUDA_INCLUDE_DIRS})
 endif()
 
-find_library(CAFFE2_LIB Caffe2_CPU)
-find_library(CAFFE2_GPU_LIB Caffe2_GPU)
+find_library(CAFFE2_LIB caffe2)
+find_library(CAFFE2_GPU_LIB caffe2_gpu)
 find_library(GLOG_LIB glog)
 find_library(GFLAGS_LIB gflags)
 find_library(NCCL_LIB nccl) # Somehow necessary to prevent "undefined reference to `ncclReduceScatter'"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ find_library(GLOG_LIB glog)
 find_library(GFLAGS_LIB gflags)
 find_library(NCCL_LIB nccl) # Somehow necessary to prevent "undefined reference to `ncclReduceScatter'"
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -std=c++11 -fPIC ")
+
 if(NOT CAFFE2_LIB)
   message(FATAL_ERROR "Caffe2 lib not found")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ find_library(GLOG_LIB glog)
 find_library(GFLAGS_LIB gflags)
 find_library(NCCL_LIB nccl) # Somehow necessary to prevent "undefined reference to `ncclReduceScatter'"
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -std=c++11 -fPIC ")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC ")
 
 if(NOT CAFFE2_LIB)
   message(FATAL_ERROR "Caffe2 lib not found")


### PR DESCRIPTION
1. Add CMAKE_CXX_FLAGS for setting up C++11 standard
2. Fixe the library name of CAFFE2_LIB and CAFFE2_GPU_LIB